### PR TITLE
Refactoring to use feathers-socket-commons that support event filtering

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "debug": "^2.2.0",
-    "feathers-commons": "^0.5.0",
+    "feathers-socket-commons": "^0.1.0",
     "socket.io": "^1.3.7",
     "uberproto": "^1.2.0"
   },
@@ -56,6 +56,7 @@
     "babel-plugin-transform-object-assign": "^6.3.13",
     "babel-preset-es2015": "^6.3.13",
     "feathers": "^2.0.0-pre.1",
+    "feathers-commons": "^0.6.0",
     "feathers-memory": "^0.5.1",
     "jshint": "^2.8.0",
     "lodash": "^3.10.1",

--- a/src/client.js
+++ b/src/client.js
@@ -1,4 +1,4 @@
-import Service from 'feathers-commons/lib/sockets/client';
+import Service from 'feathers-socket-commons/client';
 
 export default function(connection) {
   if(!connection) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import makeDebug from 'debug';
 import socketio from 'socket.io';
 import Proto from 'uberproto';
-import { socket as commons } from 'feathers-commons';
+import socket from 'feathers-socket-commons';
 
 const debug = makeDebug('feathers-socketio');
 
@@ -9,8 +9,9 @@ export default function (config) {
   return function () {
     const app = this;
 
+    app.configure(socket);
+
     Proto.mixin({
-      service: commons.service,
       setup(server) {
         const io = this.io = socketio.listen(server);
 
@@ -24,11 +25,7 @@ export default function (config) {
           config.call(this, io);
         }
 
-        const result = this._super.apply(this, arguments);
-
-        debug('Setting up SocketIO');
-
-        commons.setup.call(this, {
+        this._socketInfo = {
           method: 'emit',
           connection() {
             return io.sockets;
@@ -39,9 +36,9 @@ export default function (config) {
           params(socket) {
             return socket.feathers;
           }
-        });
+        };
 
-        return result;
+        return this._super.apply(this, arguments);
       }
     }, app);
   };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,19 +2,21 @@ import assert from 'assert';
 import _ from 'lodash';
 import feathers from 'feathers';
 import io from 'socket.io-client';
-import { Service as todoService, verify } from 'feathers-commons/lib/test-fixture';
+import { Service as todoService } from 'feathers-commons/lib/test-fixture';
 
+import testService from './service.test.js';
 import socketio from '../src';
 
 describe('feathers-socketio', () => {
-  let server, socket, app,
-    socketParams = {
+  let options = {
+    socketParams: {
       user: { name: 'David' },
       provider: 'socketio'
-    };
+    }
+  };
 
   before(done => {
-    app = feathers()
+    const app = options.app = feathers()
       .configure(socketio(function(io) {
         io.use(function (socket, next) {
           socket.feathers.user = { name: 'David' };
@@ -23,17 +25,17 @@ describe('feathers-socketio', () => {
       }))
       .use('/todo', todoService);
 
-    server = app.listen(7886, function(){
+    options.server = app.listen(7886, function(){
       app.use('/tasks', todoService);
     });
 
-    socket = io('http://localhost:7886');
+    const socket = options.socket = io('http://localhost:7886');
     socket.on('connect', () => done());
   });
 
   after(done => {
-    socket.disconnect();
-    server.close(done);
+    options.socket.disconnect();
+    options.server.close(done);
   });
 
   it('is CommonJS compatible', () => assert.equal(typeof require('../lib'), 'function'));
@@ -59,7 +61,7 @@ describe('feathers-socketio', () => {
   });
 
   it('passes handshake as service parameters', done => {
-    let service = app.service('todo');
+    let service = options.app.service('todo');
     let old = {
       find: service.find,
       create: service.create,
@@ -68,12 +70,12 @@ describe('feathers-socketio', () => {
     };
 
     service.find = function(params) {
-      assert.deepEqual(_.omit(params, 'query'), socketParams, 'Handshake parameters passed on proper position');
+      assert.deepEqual(_.omit(params, 'query'), options.socketParams, 'Handshake parameters passed on proper position');
       old.find.apply(this, arguments);
     };
 
     service.create = function(data, params) {
-      assert.deepEqual(_.omit(params, 'query'), socketParams, 'Passed handshake parameters');
+      assert.deepEqual(_.omit(params, 'query'), options.socketParams, 'Passed handshake parameters');
       old.create.apply(this, arguments);
     };
 
@@ -82,12 +84,12 @@ describe('feathers-socketio', () => {
         query: {
           test: 'param'
         }
-      }, socketParams), 'Passed handshake parameters as query');
+      }, options.socketParams), 'Passed handshake parameters as query');
       old.update.apply(this, arguments);
     };
 
-    socket.emit('todo::create', {}, {}, function () {
-      socket.emit('todo::update', 1, {}, { test: 'param' }, function() {
+    options.socket.emit('todo::create', {}, {}, function () {
+      options.socket.emit('todo::update', 1, {}, { test: 'param' }, function() {
         _.extend(service, old);
         done();
       });
@@ -95,453 +97,22 @@ describe('feathers-socketio', () => {
   });
 
   it('missing parameters in socket call works (#88)', done => {
-    let service = app.service('todo');
+    let service = options.app.service('todo');
     let old = {
       find: service.find
     };
 
     service.find = function(params) {
-      assert.deepEqual(_.omit(params, 'query'), socketParams, 'Handshake parameters passed on proper position');
+      assert.deepEqual(_.omit(params, 'query'), options.socketParams, 'Handshake parameters passed on proper position');
       old.find.apply(this, arguments);
     };
 
-    socket.emit('todo::find', function () {
+    options.socket.emit('todo::find', function () {
       _.extend(service, old);
       done();
     });
   });
 
-  describe('Services', () => {
-    it('invalid arguments cause an error', done => {
-      socket.emit('todo::find', 1, {}, function(error) {
-        assert.equal(error.message, 'Too many arguments for \'find\' service method');
-        done();
-      });
-    });
-
-    describe('CRUD', () => {
-      it('::find', function (done) {
-        socket.emit('todo::find', {}, function (error, data) {
-          verify.find(data);
-
-          done(error);
-        });
-      });
-
-      it('::get', done => {
-        socket.emit('todo::get', 'laundry', {}, function (error, data) {
-          verify.get('laundry', data);
-
-          done(error);
-        });
-      });
-
-      it('::create', done => {
-        let original = {
-          name: 'creating'
-        };
-
-        socket.emit('todo::create', original, {}, function (error, data) {
-          verify.create(original, data);
-
-          done(error);
-        });
-      });
-
-      it('::create without parameters and callback', done => {
-        let original = {
-          name: 'creating'
-        };
-
-        socket.emit('todo::create', original);
-
-        socket.once('todo created', function(data) {
-          verify.create(original, data);
-
-          done();
-        });
-      });
-
-      it('::update', done => {
-        let original = {
-          name: 'updating'
-        };
-
-        socket.emit('todo::update', 23, original, {}, function (error, data) {
-          verify.update(23, original, data);
-
-          done(error);
-        });
-      });
-
-      it('::update many', done => {
-        let original = {
-          name: 'updating',
-          many: true
-        };
-
-        socket.emit('todo::update', null, original, {}, function (error, data) {
-          verify.update(null, original, data);
-
-          done(error);
-        });
-      });
-
-      it('::patch', done => {
-        let original = {
-          name: 'patching'
-        };
-
-        socket.emit('todo::patch', 25, original, {}, function (error, data) {
-          verify.patch(25, original, data);
-
-          done(error);
-        });
-      });
-
-      it('::patch many', done => {
-        let original = {
-          name: 'patching',
-          many: true
-        };
-
-        socket.emit('todo::patch', null, original, {}, function (error, data) {
-          verify.patch(null, original, data);
-
-          done(error);
-        });
-      });
-
-      it('::remove', done => {
-        socket.emit('todo::remove', 11, {}, function (error, data) {
-          verify.remove(11, data);
-
-          done(error);
-        });
-      });
-
-      it('::remove many', done => {
-        socket.emit('todo::remove', null, {}, function (error, data) {
-          verify.remove(null, data);
-
-          done(error);
-        });
-      });
-    });
-
-    describe('Events', () => {
-      it('created', done => {
-        let original = {
-          name: 'created event'
-        };
-
-        socket.once('todo created', function (data) {
-          verify.create(original, data);
-          done();
-        });
-
-        socket.emit('todo::create', original, {}, function () {});
-      });
-
-      it('updated', done => {
-        let original = {
-          name: 'updated event'
-        };
-
-        socket.once('todo updated', function (data) {
-          verify.update(10, original, data);
-          done();
-        });
-
-        socket.emit('todo::update', 10, original, {}, function () {});
-      });
-
-      it('patched', done => {
-        let original = {
-          name: 'patched event'
-        };
-
-        socket.once('todo patched', function (data) {
-          verify.patch(12, original, data);
-          done();
-        });
-
-        socket.emit('todo::patch', 12, original, {}, function () {});
-      });
-
-      it('removed', done => {
-        socket.once('todo removed', function (data) {
-          verify.remove(333, data);
-          done();
-        });
-
-        socket.emit('todo::remove', 333, {}, function () {});
-      });
-
-      it('custom events', done => {
-        let service = app.service('todo');
-        let original = {
-          name: 'created event'
-        };
-        let old = service.create;
-
-        service.create = function(data) {
-          this.emit('log', { message: 'Custom log event', data: data });
-          service.create = old;
-          return old.apply(this, arguments);
-        };
-
-        socket.once('todo log', function(data) {
-          assert.deepEqual(data, { message: 'Custom log event', data: original });
-          done();
-        });
-
-        socket.emit('todo::create', original, {}, function () {});
-      });
-    });
-
-    describe('Event filtering', () => {
-      before(done => setTimeout(done, 20));
-
-      it('.created', done => {
-        let service = app.service('todo');
-        let original = { description: 'created event test' };
-        let oldCreated = service.created;
-
-        service.created = function(data, params, callback) {
-          assert.deepEqual(params, socketParams);
-          verify.create(original, data);
-
-          callback(null, _.extend({ processed: true }, data));
-        };
-
-        socket.emit('todo::create', original, {}, function() {});
-
-        socket.once('todo created', function (data) {
-          service.created = oldCreated;
-          // Make sure Todo got processed
-          verify.create(_.extend({ processed: true }, original), data);
-          done();
-        });
-      });
-
-      it('.updated', done => {
-        let original = {
-          name: 'updated event'
-        };
-
-        socket.once('todo updated', function (data) {
-          verify.update(10, original, data);
-          done();
-        });
-
-        socket.emit('todo::update', 10, original, {}, function () {});
-      });
-
-      it('.removed', done => {
-        let service = app.service('todo');
-        let oldRemoved = service.removed;
-
-        service.removed = function(data, params, callback) {
-          assert.deepEqual(params, socketParams);
-
-          if(data.id === 23) {
-            // Only dispatch with given id
-            return callback(null, data);
-          }
-
-          callback(null, false);
-        };
-
-        socket.emit('todo::remove', 1, {}, function() {});
-        socket.emit('todo::remove', 23, {}, function() {});
-
-        socket.on('todo removed', function (data) {
-          service.removed = oldRemoved;
-          assert.equal(data.id, 23);
-          done();
-        });
-      });
-    });
-  });
-
-  describe('Dynamic Services', () =>{
-    describe('CRUD', function () {
-      it('::find', done => {
-        socket.emit('tasks::find', {}, function (error, data) {
-          verify.find(data);
-
-          done(error);
-        });
-      });
-
-      it('::get', done => {
-        socket.emit('tasks::get', 'laundry', {}, function (error, data) {
-          verify.get('laundry', data);
-
-          done(error);
-        });
-      });
-
-      it('::create', done => {
-        let original = {
-          name: 'creating'
-        };
-
-        socket.emit('tasks::create', original, {}, function (error, data) {
-          verify.create(original, data);
-
-          done(error);
-        });
-      });
-
-      it('::update', done => {
-        let original = {
-          name: 'updating'
-        };
-
-        socket.emit('tasks::update', 23, original, {}, function (error, data) {
-          verify.update(23, original, data);
-
-          done(error);
-        });
-      });
-
-      it('::patch', done => {
-        let original = {
-          name: 'patching'
-        };
-
-        socket.emit('tasks::patch', 25, original, {}, function (error, data) {
-          verify.patch(25, original, data);
-
-          done(error);
-        });
-      });
-
-      it('::remove', done => {
-        socket.emit('tasks::remove', 11, {}, function (error, data) {
-          verify.remove(11, data);
-
-          done(error);
-        });
-      });
-    });
-
-    describe('Events', function () {
-      it('created', done => {
-        let original = {
-          name: 'created event'
-        };
-
-        socket.once('tasks created', function (data) {
-          verify.create(original, data);
-          done();
-        });
-
-        socket.emit('tasks::create', original, {}, function () {});
-      });
-
-      it('updated', done => {
-        let original = {
-          name: 'updated event'
-        };
-
-        socket.once('tasks updated', function (data) {
-          verify.update(10, original, data);
-          done();
-        });
-
-        socket.emit('tasks::update', 10, original, {}, function () {});
-      });
-
-      it('patched', done => {
-        let original = {
-          name: 'patched event'
-        };
-
-        socket.once('tasks patched', function (data) {
-          verify.patch(12, original, data);
-          done();
-        });
-
-        socket.emit('tasks::patch', 12, original, {}, function () {});
-      });
-
-      it('removed', done => {
-        socket.once('tasks removed', function (data) {
-          verify.remove(333, data);
-          done();
-        });
-
-        socket.emit('tasks::remove', 333, {}, function () {});
-      });
-    });
-
-    describe('Event Filtering', function() {
-      it('.created', done => {
-        let service = app.service('tasks');
-        let original = { description: 'created event test' };
-        let oldCreated = service.created;
-
-        service.created = function(data, params, callback) {
-          assert.ok(service === this);
-          assert.deepEqual(params, socketParams);
-          verify.create(original, data);
-
-          callback(null, _.extend({ processed: true }, data));
-        };
-
-        socket.emit('tasks::create', original, {}, function() {});
-
-        socket.once('tasks created', function (data) {
-          service.created = oldCreated;
-          // Make sure Todo got processed
-          verify.create(_.extend({ processed: true }, original), data);
-          done();
-        });
-      });
-
-      it('.updated', done => {
-        // TODO this is not testing the right thing
-        // but we will get better event filtering in v2 anyway
-        let original = {
-          name: 'updated event'
-        };
-
-        socket.once('tasks updated', function (data) {
-          verify.update(10, original, data);
-          done();
-        });
-
-        socket.emit('tasks::update', 10, original, {}, function () {});
-      });
-
-      it('.removed', done => {
-        let service = app.service('tasks');
-        let oldRemoved = service.removed;
-
-        service.removed = function(data, params, callback) {
-          assert.ok(service === this);
-          assert.deepEqual(params, socketParams);
-
-          if(data.id === 23) {
-            // Only dispatch with given id
-            return callback(null, data);
-          }
-
-          callback(null, false);
-        };
-
-        socket.emit('tasks::remove', 1, {}, function() {});
-        socket.emit('tasks::remove', 23, {}, function() {});
-
-        socket.on('tasks removed', function (data) {
-          service.removed = oldRemoved;
-          assert.equal(data.id, 23);
-          done();
-        });
-      });
-    });
-  });
+  describe('Services', () => testService('todo', options));
+  describe('Dynamic Services', () => testService('tasks', options));
 });

--- a/test/service.test.js
+++ b/test/service.test.js
@@ -1,0 +1,367 @@
+import assert from 'assert';
+import { verify } from 'feathers-commons/lib/test-fixture';
+
+export default function(name, options) {
+  it(`invalid arguments cause an error`, done => {
+    options.socket.emit(`${name}::find`, 1, {}, function(error) {
+      assert.equal(error.message, `Too many arguments for 'find' service method`);
+      done();
+    });
+  });
+
+  describe(`CRUD`, () => {
+    it(`::find`, function (done) {
+      options.socket.emit(`${name}::find`, {}, function (error, data) {
+        verify.find(data);
+
+        done(error);
+      });
+    });
+
+    it(`::get`, done => {
+      options.socket.emit(`${name}::get`, `laundry`, {}, function (error, data) {
+        verify.get(`laundry`, data);
+
+        done(error);
+      });
+    });
+
+    it(`::create`, done => {
+      let original = {
+        name: `creating`
+      };
+
+      options.socket.emit(`${name}::create`, original, {}, function (error, data) {
+        verify.create(original, data);
+
+        done(error);
+      });
+    });
+
+    it(`::create without parameters and callback`, done => {
+      let original = {
+        name: `creating`
+      };
+
+      options.socket.emit(`${name}::create`, original);
+
+      options.socket.once(`${name} created`, function(data) {
+        verify.create(original, data);
+
+        done();
+      });
+    });
+
+    it(`::update`, done => {
+      let original = {
+        name: `updating`
+      };
+
+      options.socket.emit(`${name}::update`, 23, original, {}, function (error, data) {
+        verify.update(23, original, data);
+
+        done(error);
+      });
+    });
+
+    it(`::update many`, done => {
+      let original = {
+        name: `updating`,
+        many: true
+      };
+
+      options.socket.emit(`${name}::update`, null, original, {}, function (error, data) {
+        verify.update(null, original, data);
+
+        done(error);
+      });
+    });
+
+    it(`::patch`, done => {
+      let original = {
+        name: `patching`
+      };
+
+      options.socket.emit(`${name}::patch`, 25, original, {}, function (error, data) {
+        verify.patch(25, original, data);
+
+        done(error);
+      });
+    });
+
+    it(`::patch many`, done => {
+      let original = {
+        name: `patching`,
+        many: true
+      };
+
+      options.socket.emit(`${name}::patch`, null, original, {}, function (error, data) {
+        verify.patch(null, original, data);
+
+        done(error);
+      });
+    });
+
+    it(`::remove`, done => {
+      options.socket.emit(`${name}::remove`, 11, {}, function (error, data) {
+        verify.remove(11, data);
+
+        done(error);
+      });
+    });
+
+    it(`::remove many`, done => {
+      options.socket.emit(`${name}::remove`, null, {}, function (error, data) {
+        verify.remove(null, data);
+
+        done(error);
+      });
+    });
+  });
+
+  describe(`Events`, () => {
+    it(`created`, done => {
+      let original = {
+        name: `created event`
+      };
+
+      options.socket.once(`${name} created`, function (data) {
+        verify.create(original, data);
+        done();
+      });
+
+      options.socket.emit(`${name}::create`, original, {}, function () {});
+    });
+
+    it(`updated`, done => {
+      let original = {
+        name: `updated event`
+      };
+
+      options.socket.once(`${name} updated`, function (data) {
+        verify.update(10, original, data);
+        done();
+      });
+
+      options.socket.emit(`${name}::update`, 10, original, {}, function () {});
+    });
+
+    it(`patched`, done => {
+      let original = {
+        name: `patched event`
+      };
+
+      options.socket.once(`${name} patched`, function (data) {
+        verify.patch(12, original, data);
+        done();
+      });
+
+      options.socket.emit(`${name}::patch`, 12, original, {}, function () {});
+    });
+
+    it(`removed`, done => {
+      options.socket.once(`${name} removed`, function (data) {
+        verify.remove(333, data);
+        done();
+      });
+
+      options.socket.emit(`${name}::remove`, 333, {}, function () {});
+    });
+
+    it(`custom events`, done => {
+      let service = options.app.service(name);
+      let original = {
+        name: `created event`
+      };
+      let old = service.create;
+
+      service.create = function(data) {
+        this.emit(`log`, { message: `Custom log event`, data: data });
+        service.create = old;
+        return old.apply(this, arguments);
+      };
+
+      options.socket.once(`${name} log`, function(data) {
+        assert.deepEqual(data, { message: `Custom log event`, data: original });
+        done();
+      });
+
+      options.socket.emit(`${name}::create`, original, {}, function () {});
+    });
+  });
+
+  describe(`Event filtering`, () => {
+    before(done => setTimeout(done, 20));
+
+    it(`.created`, done => {
+      let service = options.app.service(name);
+      let original = { description: `created event test` };
+      let oldCreated = service.created;
+
+      service.created = function(data, params, callback) {
+        assert.deepEqual(params, options.socketParams);
+        verify.create(original, data);
+
+        callback(null, Object.assign({ processed: true }, data));
+      };
+
+      options.socket.emit(`${name}::create`, original, {}, function() {});
+
+      options.socket.once(`${name} created`, function (data) {
+        service.created = oldCreated;
+        // Make sure ${name} got processed
+        verify.create(Object.assign({ processed: true }, original), data);
+        done();
+      });
+    });
+
+    it(`.removed`, done => {
+      let service = options.app.service(name);
+      let oldRemoved = service.removed;
+
+      service.removed = function(data, params, callback) {
+        assert.deepEqual(params, options.socketParams);
+
+        if(data.id === 23) {
+          // Only dispatch with given id
+          return callback(null, data);
+        }
+
+        callback(null, false);
+      };
+
+      options.socket.emit(`${name}::remove`, 1, {}, function() {});
+      options.socket.emit(`${name}::remove`, 23, {}, function() {});
+
+      options.socket.once(`${name} removed`, function (data) {
+        service.removed = oldRemoved;
+        assert.equal(data.id, 23);
+        done();
+      });
+    });
+
+    it(`adds service.filter and registers event callback`, () => {
+      let service = options.app.service(name);
+
+      assert.equal(typeof service.filter, `function`);
+      assert.equal(typeof service._eventFilters, `object`);
+
+      service.filter(`created`, function() {});
+      assert.equal(service._eventFilters.created.length, 1);
+
+      service._eventFilters = {};
+    });
+
+    it(`filters an event and passes the right parameters`, done => {
+      let service = options.app.service(name);
+      let original = { description: `created event test` };
+
+      service.filter(`created`, function(data, connection, hook) {
+        assert.deepEqual(connection, options.socketParams);
+        assert.deepEqual(hook.params, {
+          query: { test: true },
+          provider: `socketio`,
+          user: { name: `David` }
+        });
+
+        verify.create(original, data);
+
+        return Object.assign({ processed: true }, data);
+      });
+
+      options.socket.emit(`${name}::create`, original, { test: true });
+
+      options.socket.once(`${name} created`, function (data) {
+        service._eventFilters = {};
+        // Make sure ${name} got processed
+        verify.create(Object.assign({ processed: true }, original), data);
+        done();
+      });
+    });
+
+    it(`chains filters of different types and lets you modify data`, done => {
+      let service = options.app.service(name);
+      let original = { description: `created event test` };
+
+      service.filter(`created`, [
+        function(data) {
+          return Object.assign({ processed: true }, data);
+        },
+
+        function(data, connection, hook, callback) {
+          data = Object.assign({ next: true }, data);
+          callback(null, data);
+        }
+      ]);
+
+      options.socket.emit(`${name}::create`, original, { test: true });
+
+      options.socket.once(`${name} created`, function (data) {
+        service._eventFilters = {};
+        // Make sure ${name} got processed
+        verify.create(Object.assign({
+          processed: true,
+          next: true
+        }, original), data);
+        done();
+      });
+    });
+
+    it(`filter errors stop execution and send pathed error`, done => {
+      let service = options.app.service(name);
+      let original = { description: `created event test` };
+
+      service.filter(`created`, [
+        function() {
+          throw new Error(`Nooo!`);
+        },
+
+        function() {
+          assert.ok(false, `Should never get here`);
+        }
+      ]);
+
+      options.socket.once(`${name} error`, error => {
+        assert.equal(error.message, `Nooo!`);
+        service._eventFilters = {};
+        done();
+      });
+
+      options.socket.emit(`${name}::create`, original, { test: true });
+    });
+
+    it(`stops execution when a filter returns falsy`, done => {
+      let service = options.app.service(name);
+
+      service.filter(`removed`, [
+        function(data, connection) {
+          assert.deepEqual(connection, options.socketParams);
+
+          if(data.id === 23) {
+            // Only dispatch with given id
+            return data;
+          }
+
+          return false;
+        },
+
+        function(data) {
+          if(data.id !== 23) {
+            assert.ok(false, `Should never get here`);
+          }
+          return data;
+        }
+      ]);
+
+
+      options.socket.emit(`${name}::remove`, 1, {}, function() {});
+      options.socket.emit(`${name}::remove`, 23, {}, function() {});
+
+      options.socket.once(`${name} removed`, function (data) {
+        assert.equal(data.id, 23);
+        service._eventFilters = {};
+        done();
+      });
+    });
+  });
+}


### PR DESCRIPTION
This pull request migrates use to the feathers-socket-commons module which supports event filtering functionality (see #2).