### PR TITLE
Allow to instantiate a client instance

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -4,11 +4,22 @@ export default function(connection) {
   if(!connection) {
     throw new Error('Socket.io connection needs to be provided');
   }
-
-  return function() {
-    this.io = connection;
-    this.defaultService = function(name) {
-      return new Service({ name, connection, method: 'emit' });
-    };
+  
+  const defaultService = function(name) {
+    return new Service({ name, connection, method: 'emit' });
   };
+
+  const initialize = function() {
+    if(typeof this.defaultService === 'function') {
+      throw new Error('Only one default client provider can be configured');
+    }
+    
+    this.io = connection;
+    this.defaultService = defaultService;
+  };
+  
+  initialize.Service = Service;
+  initialize.service = defaultService;
+  
+  return initialize;
 }

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -32,6 +32,29 @@ describe('feathers-socketio/client', function() {
   it('app has the io attribute', () => {
     assert.ok(app.io);
   });
+  
+  it('throws an error when configured twice', () => {
+    try {
+      app.configure(socketio(socket));
+      assert.ok(false, 'Should never get here');
+    } catch (e) {
+      assert.equal(e.message, 'Only one default client provider can be configured');
+    }
+  });
+  
+  it('can initialize a client instance', done => {
+    const init = socketio(socket);
+    const todos = init.service('todos');
+    
+    assert.ok(todos instanceof init.Service, 'Returned service is a client');
+    todos.find({}).then(todos => assert.deepEqual(todos, [
+      {
+        text: 'some todo',
+        complete: false,
+        id: 0
+      }
+    ])).then(() => done()).catch(done);
+  });
 
   baseTests(service);
 });


### PR DESCRIPTION
This allows to instantiate a standalone client service like:

```js
const socketio = require('feathers-socketio/client');

const todoService = socketio(socket).service('todos');
```

Also throws an error when configured twice on the client.