### PR TITLE
fix link in README.md to feathers-socketio API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This provider exposes [Feathers](http://feathersjs.com) services through a [Socket.io](http://socket.io/) real-time API. It is compatible with Feathers 1.x and 2.x.
 
-__Note:__ For the full API documentation go to [feathersjs.com/docs/providers.html](http://feathersjs.com/docs/providers.html).
+__Note:__ For the full API documentation go to [http://docs.feathersjs.com/real-time/socket-io.html](http://docs.feathersjs.com/real-time/socket-io.html).
 
 ## Quick example
 


### PR DESCRIPTION
Fixes #23 - correct link in README.md to feathers-socketio API documentation 