### PR TITLE
Add option to set the maxListeners

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,11 +29,6 @@ export default function (options, config) {
           });
         }
 
-        if (typeof config === 'function') {
-          debug('Calling SocketIO configuration function');
-          config.call(this, io);
-        }
-
         this._socketInfo = {
           method: 'emit',
           connection () {
@@ -51,6 +46,11 @@ export default function (options, config) {
         // of event listeners (e.g. by registering 10 services).
         // So we set it to a higher number. 64 should be enough for everyone.
         this._socketInfo.connection().setMaxListeners(64);
+
+        if (typeof config === 'function') {
+          debug('Calling SocketIO configuration function');
+          config.call(this, io);
+        }
 
         return this._super.apply(this, arguments);
       }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -76,6 +76,18 @@ describe('feathers-socketio', () => {
     let srv = app.listen(8887).on('listening', () => srv.close(done));
   });
 
+  it('can set MaxListeners', done => {
+    let app = feathers()
+      .configure(socketio(function (io) {
+        io.sockets.setMaxListeners(100);
+      }));
+
+    let srv = app.listen(8987).on('listening', () => {
+      assert.equal(app.io.sockets.getMaxListeners(), 100);
+      srv.close(done);
+    });
+  });
+
   it('can set options (#12)', done => {
     let app = feathers()
       .configure(socketio({


### PR DESCRIPTION
### Summary
Offers the possibility to overwrite the socket.io MaxListeners.

- [x] Tell us about the problem your pull request is solving.
- [ ] Are there any open issues that are related to this?
- [ ] Is this PR dependent on PRs in other repos?

### Other Information
Since the config is called before the setMaxListeners, does not overwrites it.
