### PR TITLE
Server-side socketio typedef to allow `import * as` syntax when importing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ type FeathersSockeOptions =
 
 
 declare function feathersSocketIO(
-    options: FeathersSockeOptions,
+    options?: FeathersSockeOptions,
     config?: FeathersSockeOptions
   ): () => void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,9 +8,11 @@ type FeathersSockeOptions =
   FeatherSocketCallback;
 
 
-declare function e(
+declare function feathersSocketIO(
     options: FeathersSockeOptions,
     config?: FeathersSockeOptions
   ): () => void;
 
-export = e;
+declare namespace feathersSocketIO {}
+
+export = feathersSocketIO;


### PR DESCRIPTION
I thought #64 fixed the issue.  Didn't realize it was for client.d.ts.