### PR TITLE
Attach socket.io server to separate port

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,8 @@ export default function (options, config) {
         let io = this.io;
 
         if (!io) {
-          io = this.io = socketio.listen(server, options);
+          const port = options && options.port;
+          io = this.io = socketio.listen(port || server, options);
 
           io.use(function (socket, next) {
             socket.feathers = { provider: 'socketio' };


### PR DESCRIPTION
Hello, I need to start socket.io server on another port. Not on Node.js server port. 
I have a microservice that hasn't public access, but I must emit some events to UI. If I open only access to socket.io port it can be possible.

Socket.io has ability to listen `port` or `httpServer`. Let's add the same option to this package.
```
server.listen(httpServer[, options])
Synonym of server.attach(httpServer[, options]).

server.listen(port[, options])
Synonym of server.attach(port[, options]).```